### PR TITLE
Fix: Exclude adapt-contrib-core from list of installable plugins (fixes #21)

### DIFF
--- a/lib/Setup.js
+++ b/lib/Setup.js
@@ -85,8 +85,10 @@ export default class Setup {
 	async getPluginChoices(answers, input) {
 		const getPluginsByUser = user => {
 			const list = this.plugins.filter(({ url, name }) => {
+				const nameLowercase = name.toLowerCase();
 				return url.split("/")[3] === user &&
-					name.toLowerCase().includes(input.toLowerCase());
+					nameLowercase.includes(input.toLowerCase()) &&
+					!this.isCorePlugin(nameLowercase);
 			});
 
 			return list.length ? [ this.getSeparator(user), ...list.reverse() ] : list;
@@ -112,6 +114,19 @@ export default class Setup {
 			...getPluginsByUser("cgkineo"),
 			...getThirdPartyPlugins()
 		];
+	}
+
+	/**
+	 * Check whether the supplied plugin is 'adapt-contrib-core'
+	 * 
+	 * Note: This will not be needed in Adapt v6 as the core plugin
+	 * will be an installable npm package.
+	 * 
+	 * @param {name} Plugin name
+	 * @returns {boolean}
+	 */
+	isCorePlugin(name) {
+		return name.toLowerCase().includes('adapt-contrib-core');
 	}
 
 	getSeparator(label) {


### PR DESCRIPTION
Fix #21 

### Fix
* Exclude `adapt-contrib-core` from list of installable plugins

### Notes
* This should be removed once Adapt v6 is released. Alternatively, we could check for the framework version when running `adapt-setup`, but this will add more complication.

### Testing
1. Run `adapt-setup`
2. Ensure `adapt-contrib-core` is not listed as an installable plugin
